### PR TITLE
CFLAGS/CXXFLAGS for macOS universal builds (x86_64 + arm64)

### DIFF
--- a/macos/makefile
+++ b/macos/makefile
@@ -18,6 +18,10 @@ O = o
 #O = o
 #O = obj
 
+# MAC Universal Binary
+CFLAGS += -std=gnu89 -Wno-implicit-function-declaration -arch arm64 -arch x86_64
+CXXFLAGS += -std=c++98 -arch arm64 -arch x86_64
+
 OBJECTS = cconfiguracion.$(O) cmemoria.$(O) cbancoregistros.$(O) \
           cprocesador.$(O) cinstruccion.$(O) cgestorinstrucciones.$(O) \
           centero16b.$(O) centradasalida.$(O) cinterfazconsola.$(O) \
@@ -29,65 +33,65 @@ OBJECTS = cconfiguracion.$(O) cmemoria.$(O) cbancoregistros.$(O) \
 DEFS = definiciones.h cadenas_ansi.h cadenas_ascii.h compilacion.h
 
 $(ENS2001) : ens2001.cpp $(OBJECTS)
-	$(CC++) -o$(ENS2001) ens2001.cpp $(OBJECTS)
+	$(CC++) $(CXXFLAGS) -o$(ENS2001) ens2001.cpp $(OBJECTS)
 	
 cconfiguracion.$(O) : cconfiguracion.cpp cconfiguracion.h $(DEFS) defscpp.h \
                       cmemoria.h cbancoregistros.h cprocesador.h \
                       cgestorpuntosruptura.h
-	$(CC++) -c cconfiguracion.cpp
+	$(CC++) $(CXXFLAGS) -c cconfiguracion.cpp
 	
 cmemoria.$(O) : cmemoria.cpp cmemoria.h $(DEFS) defscpp.h cconfiguracion.h
-	$(CC++) -c cmemoria.cpp
+	$(CC++) $(CXXFLAGS) -c cmemoria.cpp
 	
 cbancoregistros.$(O) : cbancoregistros.cpp cbancoregistros.h $(DEFS) defscpp.h \
                        cconfiguracion.h
-	$(CC++) -c cbancoregistros.cpp
+	$(CC++) $(CXXFLAGS) -c cbancoregistros.cpp
 	
 cprocesador.$(O) : cprocesador.cpp cprocesador.h $(DEFS) defscpp.h
-	$(CC++) -c cprocesador.cpp
+	$(CC++) $(CXXFLAGS) -c cprocesador.cpp
 	
 cinstruccion.$(O) : cinstruccion.cpp cinstruccion.h $(DEFS) defscpp.h \
                     cconfiguracion.h centradasalida.h
-	$(CC++) -c cinstruccion.cpp
+	$(CC++) $(CXXFLAGS) -c cinstruccion.cpp
 	
 cgestorinstrucciones.$(O) : cgestorinstrucciones.cpp cgestorinstrucciones.h \
                             $(DEFS) defscpp.h cinstruccion.h cconfiguracion.h
-	$(CC++) -c cgestorinstrucciones.cpp	
+	$(CC++) $(CXXFLAGS) -c cgestorinstrucciones.cpp	
 
 centero16b.$(O) : centero16b.cpp centero16b.h $(DEFS) defscpp.h
-	$(CC++) -c centero16b.cpp
+	$(CC++) $(CXXFLAGS) -c centero16b.cpp
 	
 centradasalida.$(O) : centradasalida.cpp centradasalida.h $(DEFS) defscpp.h \
                       cconfiguracion.h
-	$(CC++) -c centradasalida.cpp
+	$(CC++) $(CXXFLAGS) -c centradasalida.cpp
 	
 cinterfazconsola.$(O) : cinterfazconsola.cpp cinterfazconsola.h $(DEFS) \
                         defscpp.h cconfiguracion.h cdesensamblador.h \
                         censamblador.h cinterfazdisco.h ens_tab.h
-	$(CC++) -c cinterfazconsola.cpp
+	$(CC++) $(CXXFLAGS) -c cinterfazconsola.cpp
 	
 cdesensamblador.$(O) : cdesensamblador.cpp cdesensamblador.h $(DEFS) defscpp.h \
                        cconfiguracion.h
-	$(CC++) -c cdesensamblador.cpp
+	$(CC++) $(CXXFLAGS) -c cdesensamblador.cpp
 	
 cinterfazdisco.$(O) : cinterfazdisco.cpp cinterfazdisco.h $(DEFS) defscpp.h \
                       cmemoria.h
-	$(CC++) -c cinterfazdisco.cpp
+	$(CC++) $(CXXFLAGS) -c cinterfazdisco.cpp
 	
 cgestorpuntosruptura.$(O) : cgestorpuntosruptura.cpp cgestorpuntosruptura.h \
                              $(DEFS) defscpp.h cconfiguracion.h centero16b.h
-	$(CC++) -c cgestorpuntosruptura.cpp
+	$(CC++) $(CXXFLAGS) -c cgestorpuntosruptura.cpp
 	
 censamblador.$(O) : censamblador.cpp censamblador.h $(DEFS) defscpp.h \
                     cconfiguracion.h ens_tab.h
-	$(CC++) -c censamblador.cpp
+	$(CC++) $(CXXFLAGS) -c censamblador.cpp
 
 ccadena.$(O) : ccadena.cpp ccadena.h $(DEFS) defscpp.h
-	$(CC++) -c ccadena.cpp
+	$(CC++) $(CXXFLAGS) -c ccadena.cpp
 	
 ens_lex.$(O) : ens_lex.c ens.l $(DEFS) defsc.h ens_tab.h funcionesauxiliares.h \
                gestionerrores.h
-	$(CC) -c ens_lex.c
+	$(CC) $(CFLAGS) -c ens_lex.c
 	
 ens_lex.c : ens.l $(DEFS) defsc.h ens_tab.h funcionesauxiliares.h \
             gestionerrores.h
@@ -95,7 +99,7 @@ ens_lex.c : ens.l $(DEFS) defsc.h ens_tab.h funcionesauxiliares.h \
 	 
 ens_tab.$(O) : ens_tab.c ens_tab.h ens.y $(DEFS) defsc.h funcionesauxiliares.h \
                gestionetiquetas.h gestionerrores.h gestionmemoria.h 
-	$(CC) -c ens_tab.c
+	$(CC) $(CFLAGS) -c ens_tab.c
 	
 ens_tab.c : ens.y $(DEFS) defsc.h funcionesauxiliares.h \
             gestionetiquetas.h gestionerrores.h gestionmemoria.h 
@@ -107,18 +111,18 @@ ens_tab.h : ens_tab.c
         	
 funcionesauxiliares.$(O) : funcionesauxiliares.c funcionesauxiliares.h $(DEFS) \
                            defsc.h
-	$(CC) -c funcionesauxiliares.c
+	$(CC) $(CFLAGS) -c funcionesauxiliares.c
 	
 gestionerrores.$(O) : gestionerrores.c gestionerrores.h $(DEFS) defsc.h \
                       funcionesauxiliares.h
-	$(CC) -c gestionerrores.c
+	$(CC) $(CFLAGS) -c gestionerrores.c
 	
 gestionetiquetas.$(O) : gestionetiquetas.c gestionetiquetas.h $(DEFS) defsc.h \
                         gestionerrores.h gestionmemoria.h
-	$(CC) -c gestionetiquetas.c
+	$(CC) $(CFLAGS) -c gestionetiquetas.c
 	
 gestionmemoria.$(O) : gestionmemoria.c gestionmemoria.h $(DEFS) defsc.h
-	$(CC) -c gestionmemoria.c
+	$(CC) $(CFLAGS) -c gestionmemoria.c
 	
 clean :
 	$(BORRAR) ens2001.$(O) $(OBJECTS)


### PR DESCRIPTION
Cambios en el Makefile para generar binarios universales. 
Probado en macOS Sequoia (version 15) 